### PR TITLE
docs: add exist use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 - [使用者指南](user-guide/openstack.md)
 - [FAQ](user-guide/faq.md)
 
+現有的使用案例：
+- [在 Kubernetes 用 Loki 蒐集 log 做監控警告通知方法整理筆記](https://malagege.github.io/blog/2022/04/03/%E5%9C%A8-Kubernetes-%E7%94%A8-Loki-%E8%92%90%E9%9B%86-log-%E5%81%9A%E7%9B%A3%E6%8E%A7%E8%AD%A6%E5%91%8A%E9%80%9A%E7%9F%A5%E6%96%B9%E6%B3%95%E6%95%B4%E7%90%86%E7%AD%86%E8%A8%98/)
+- [使用 CNTUG Infra Labs 編譯 Android Custom ROM](https://hackmd.io/@EdwardWu/InfraLabs_OB)
+
 This is a repository contains all documents related to Cloud Native Taiwan Infra Labs including:
 
 - [Architecture](architecture)
@@ -15,3 +19,7 @@ This is a repository contains all documents related to Cloud Native Taiwan Infra
 	- [IaaS Architecture](architecture/iaas.md)
 - [User Guide](user-guide/openstack.md)
 - [FAQ](user-guide/faq.md)
+
+Existing use cases:
+- [在 Kubernetes 用 Loki 蒐集 log 做監控警告通知方法整理筆記](https://malagege.github.io/blog/2022/04/03/%E5%9C%A8-Kubernetes-%E7%94%A8-Loki-%E8%92%90%E9%9B%86-log-%E5%81%9A%E7%9B%A3%E6%8E%A7%E8%AD%A6%E5%91%8A%E9%80%9A%E7%9F%A5%E6%96%B9%E6%B3%95%E6%95%B4%E7%90%86%E7%AD%86%E8%A8%98/)
+- [使用 CNTUG Infra Labs 編譯 Android Custom ROM](https://hackmd.io/@EdwardWu/InfraLabs_OB)


### PR DESCRIPTION
Solved #11
As discussed in the last Monthly Meeting, we can add some existing use cases in the [README.md](https://github.com/cloud-native-taiwan/Infra-Labs-Docs/blob/main/README.md) file.