### PR TITLE
feat: allow ubuntu jammy use frr offical repo

### DIFF
--- a/attachments/frr_bgp/terraform/scripts/instance_1.sh
+++ b/attachments/frr_bgp/terraform/scripts/instance_1.sh
@@ -4,11 +4,7 @@ sudo apt update
 curl -s https://deb.frrouting.org/frr/keys.asc | sudo apt-key add -
 FRRVER="frr-stable"
 
-# FRR Repo not support Ubuntu Jammy (22.04)
-if [ $(lsb_release -s -c) != "jammy" ]
-then
-    echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
-fi
+echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
 sudo apt update -y && sudo apt install -y frr frr-pythontools mtr
 
 echo "

--- a/attachments/frr_bgp/terraform/scripts/instance_2.sh
+++ b/attachments/frr_bgp/terraform/scripts/instance_2.sh
@@ -4,11 +4,7 @@ sudo apt update
 curl -s https://deb.frrouting.org/frr/keys.asc | sudo apt-key add -
 FRRVER="frr-stable"
 
-# FRR Repo not support Ubuntu Jammy (22.04)
-if [ $(lsb_release -s -c) != "jammy" ]
-then
-    echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
-fi
+echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
 sudo apt update -y && sudo apt install -y frr frr-pythontools mtr
 
 echo "

--- a/attachments/frr_bgp/terraform/scripts/router.sh
+++ b/attachments/frr_bgp/terraform/scripts/router.sh
@@ -4,11 +4,7 @@ sudo apt update
 curl -s https://deb.frrouting.org/frr/keys.asc | sudo apt-key add -
 FRRVER="frr-stable"
 
-# FRR Repo not support Ubuntu Jammy (22.04)
-if [ $(lsb_release -s -c) != "jammy" ]
-then
-    echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
-fi
+echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER | sudo tee -a /etc/apt/sources.list.d/frr.list
 sudo apt update -y && sudo apt install -y frr frr-pythontools mtr
 
 echo "


### PR DESCRIPTION
FRRouting repo now supports Ubuntu Jammy.

https://deb.frrouting.org/

<img width="1130" alt="CleanShot 2023-04-25 at 13 05 36@2x" src="https://user-images.githubusercontent.com/43361940/234179260-c39167ce-3a39-4f49-a5ee-25d118b2882d.png">
