### PR TITLE
Fix meetup link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -153,7 +153,7 @@ const config = {
               },
               {
                 label: 'Meetup 活動',
-                href: 'https://www.meetup.com/CloudNative-Taiwan/',
+                href: 'https://community.cncf.io/cloud-native-taiwan-user-group/',
               },
             ],
           },


### PR DESCRIPTION
We have deprecated the meetup site and replaced it with community.cncf.io.