### PR TITLE
fix: correct Clarity City font URLs to use @clr/city package

### DIFF
--- a/src/css/cntug-tokens.css
+++ b/src/css/cntug-tokens.css
@@ -24,35 +24,35 @@
   font-family: "Clarity City";
   font-weight: 400;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Regular/ClarityCityRegular.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Regular.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 500;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Medium/ClarityCityMedium.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Medium.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 600;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/SemiBold/ClarityCitySemiBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-SemiBold.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 700;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/Bold/ClarityCityBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-Bold.woff2") format("woff2");
   font-display: swap;
 }
 @font-face {
   font-family: "Clarity City";
   font-weight: 800;
   font-style: normal;
-  src: url("https://cdn.jsdelivr.net/npm/@clr/ui@17.12.2/dist/ExtraBold/ClarityCityExtraBold.woff2") format("woff2");
+  src: url("https://cdn.jsdelivr.net/npm/@clr/city@1.1.0/Webfonts/WOFF2/ClarityCity-ExtraBold.woff2") format("woff2");
   font-display: swap;
 }
 


### PR DESCRIPTION
## Summary

- The `@font-face` declarations in `cntug-tokens.css` were pointing to `@clr/ui@17.12.2`, which does not ship the font files at those paths (404s)
- Clarity City fonts are distributed in the separate `@clr/city` package — all five weights (400/500/600/700/800) verified HTTP 200 at `@clr/city@1.1.0` on jsDelivr before merging

## Changes

- `src/css/cntug-tokens.css`: update all five `@font-face` `src` URLs from `@clr/ui@17.12.2/dist/...` to `@clr/city@1.1.0/Webfonts/WOFF2/...`

## Test plan

- [ ] Run `yarn start` and open the site — headings and body text should render in Clarity City instead of the system fallback font
- [ ] Open DevTools → Network → filter by "woff2" — confirm all five font files return 200 (not 404)
- [ ] Run `yarn build` to confirm no broken-link or build errors